### PR TITLE
feat: añade menú hamburguesa al header

### DIFF
--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,19 +1,103 @@
 header{
     background-color: var(--grisClaro);
     width: 100%;
-    height: fit-content;
+    height: 70px;
     margin-bottom: 10px;
     text-align: center;
 }
 
 
 nav {
+    width: 80%;
+    height: 100%;
     display: flex;
-    flex-direction: column;
-    gap: 10px;
-    text-transform: uppercase;
+    justify-content: space-between;
+    align-items: center;
 }
 
 nav a:hover{
     background: var(--naranjaClaro);
+}
+
+.nav__items{
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    top: 70px; left: 0;
+    width: 100%;
+    text-transform: uppercase;
+    background: var(--grisClaro);
+    transform: translateX(-100%);
+    transition: 0.3s ease all;
+    gap: 5px;
+    text-align: start;
+}
+
+.nav__items.open{
+    transform: translateX(0);
+}
+
+.nav__items a{
+    padding-left: 10px;
+    font-size: 1.4rem;
+    font-weight: bold;
+    position: relative;
+}
+
+.nav__toggle{
+    display: flex;
+    flex-direction: column;
+    background-color: var(--naranjaClaro);
+    border-radius: 5px;
+    cursor: pointer;
+    padding: 5px;
+    align-items: center;
+    justify-content: center;
+}
+
+.nav__toggle span{
+    width: 30px;
+    height: 4px;
+    background: var(--marron);
+    margin-bottom: 5px;
+    border-radius: 3px;
+    transform-origin: 5px 0px;
+    transition: all 0.2s linear;
+}
+
+.nav__toggle span:nth-child(1){
+    margin-top: 2px;
+}
+
+
+.nav__toggle.open span:nth-child(1) {
+    transform: rotate(45deg) translate(6px, 1px);
+}
+
+.nav__toggle.open span:nth-child(2) {
+    opacity: 0;
+}
+
+.nav__toggle.open span:nth-child(3) {
+    transform: rotate(-45deg) translate(0px, 2px);
+}
+
+@media (min-width: 1000px){
+  .nav__toggle{
+    display: none;
+  }
+
+  .nav__items {
+    position: static;
+    flex-direction: row;
+    transform: none;
+    width: auto;
+    background: none;
+    gap: 0;
+}
+
+.nav__items a {
+    margin-left: 20px;
+    padding-left: 0;
+}
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,16 +1,27 @@
 import React from 'react'
 import './Header.css'
+import { useState } from 'react'
+
 const Header = () => {
+  const [isOpen, setIsOpen] = useState(false)
   return (
     <header>
     <nav className='container'>
         {/* <picture>
             <img src="" alt="" />
         </picture> */}
-            <a href="http://">Inicio</a>
-            <a href="http://">Nosotros</a>
-            <a href="http://">Contacto</a>
-            <a href="http://">Tienda</a>
+        <div className='nav__logo'>RSeH</div>
+        <div className={`nav__items ${isOpen ? 'open' : ''}`}>
+          <a href="#inicio">Inicio</a>
+          <a href="#nosotros">Nosotros</a>
+          <a href="#contacto">Contacto</a>
+          <a href="#tienda">Tienda</a>
+        </div>
+        <div className={`nav__toggle ${isOpen ? 'open' : ''}`} onClick={() => setIsOpen(!isOpen)}>
+          <span></span>
+          <span></span>
+          <span></span>
+          </div>
     </nav>
     </header>
   )


### PR DESCRIPTION
Añade un menú hamburguesa al header para la navegación en dispositivos móviles. El menú incluye enlaces a las secciones de Inicio, Nosotros, Contacto y Tienda. Se implementó la funcionalidad de apertura y cierre del menú con animaciones CSS. Se añadieron media queries para ocultar el menú hamburguesa en pantallas grandes.